### PR TITLE
Detect system architecture for correct download url

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,14 @@ install_helm_cr() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  local architecture
+  architecture=$(uname -m)
+  case $architecture in
+  armv*) architecture="armv6" ;;
+  aarch64) architecture="arm64" ;;
+  x86_64) architecture="amd64" ;;
+  esac
+  local platform="$(uname | tr '[:upper:]' '[:lower:]')_$architecture"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/helm-cr"
   local download_url=$(get_download_url $version $platform)


### PR DESCRIPTION
The helm chart releaser releases page publishes binaries for multiple system architectures and this plugin is currently hardcoded for amd64. This change will detect the host architecture, to build the correct download-url for each system type. I recently had a [pr merged](https://github.com/helm/chart-releaser/pull/139) in the main [helm/chart-releaser](https://github.com/helm/chart-releaser/) repo to enable arm64 binaries be built for linux and darwin in the next version.